### PR TITLE
added arbitrary time comparison to spot

### DIFF
--- a/test/v1/index.test.js
+++ b/test/v1/index.test.js
@@ -674,7 +674,7 @@ test('check coingecko spot price with arbitrary timeframe ticker', async (t) => 
     .expect(ok)
   const { payload } = body
   t.true(!_.isNaN(new Date(body.lastUpdated).valueOf()))
-  const key = `usd_${timeframe}_change`
+  const key = 'usd_timeframe_change'
   const bat = {
     usd: payload.bat.usd,
     usd_24h_change: payload.bat.usd_24h_change,
@@ -686,6 +686,34 @@ test('check coingecko spot price with arbitrary timeframe ticker', async (t) => 
       bat
     }
   })
+})
+
+test('check coingecko spot price with timeframe', async (t) => {
+  // normalize this testing structure elsewhere to check combinatorial features
+  const checkAgainstCurrency = async (ca, cb, timeframe) => {
+    const url = `/v2/relative/provider/coingecko/${ca}/${cb}/${timeframe}`
+    const { body } = await ratiosAgent
+      .get(url)
+      .expect(ok)
+    const { payload } = body
+    const reduced = ca.reduce((memo, key) => {
+      memo[key] = cb.reduce((memo, currency) => {
+        memo[currency] = payload[key][currency]
+        const change24Key = `${currency}_24h_change`
+        memo[change24Key] = payload[key][change24Key]
+        const changeTimeframeKey = `${currency}_timeframe_change`
+        memo[changeTimeframeKey] = payload[key][changeTimeframeKey]
+        return memo
+      }, {})
+      return memo
+    }, {})
+    t.true(!_.isNaN(new Date(body.lastUpdated).valueOf()))
+    t.deepEqual(body, {
+      lastUpdated: body.lastUpdated,
+      payload: reduced
+    })
+  }
+  await checkAgainstCurrency(['bat', 'link'], ['btc', 'usd'], '1w')
 })
 
 test('keywords can be passed to retreive historical prices', async (t) => {

--- a/test/v1/index.test.js
+++ b/test/v1/index.test.js
@@ -644,7 +644,7 @@ test('check coingecko spot price', async (t) => {
       payload: reduced
     })
   }
-  await checkAgainstCurrency(['bat', 'link'], ['btc', 'usd'])
+  await checkAgainstCurrency(['bat', 'chainlink'], ['btc', 'usd'])
 })
 
 test('check coingecko spot price with mapped ticker', async (t) => {
@@ -713,7 +713,7 @@ test('check coingecko spot price with timeframe', async (t) => {
       payload: reduced
     })
   }
-  await checkAgainstCurrency(['bat', 'link'], ['btc', 'usd'], '1w')
+  await checkAgainstCurrency(['bat', 'chainlink'], ['btc', 'usd'], '1w')
 })
 
 test('keywords can be passed to retreive historical prices', async (t) => {

--- a/test/v1/index.test.js
+++ b/test/v1/index.test.js
@@ -631,9 +631,7 @@ test('check coingecko spot price', async (t) => {
     const { payload } = body
     const reduced = ca.reduce((memo, key) => {
       memo[key] = cb.reduce((memo, currency) => {
-        const change24Key = `${currency}_24h_change`
         memo[currency] = payload[key][currency]
-        memo[change24Key] = payload[key][change24Key]
         return memo
       }, {})
       return memo
@@ -655,8 +653,7 @@ test('check coingecko spot price with mapped ticker', async (t) => {
   const { payload } = body
   t.true(!_.isNaN(new Date(body.lastUpdated).valueOf()))
   const bat = {
-    usd: payload.bat.usd,
-    usd_24h_change: payload.bat.usd_24h_change
+    usd: payload.bat.usd
   }
   t.deepEqual(body, {
     lastUpdated: body.lastUpdated,
@@ -677,7 +674,6 @@ test('check coingecko spot price with arbitrary timeframe ticker', async (t) => 
   const key = 'usd_timeframe_change'
   const bat = {
     usd: payload.bat.usd,
-    usd_24h_change: payload.bat.usd_24h_change,
     [key]: payload.bat[key]
   }
   t.deepEqual(body, {
@@ -699,8 +695,6 @@ test('check coingecko spot price with timeframe', async (t) => {
     const reduced = ca.reduce((memo, key) => {
       memo[key] = cb.reduce((memo, currency) => {
         memo[currency] = payload[key][currency]
-        const change24Key = `${currency}_24h_change`
-        memo[change24Key] = payload[key][change24Key]
         const changeTimeframeKey = `${currency}_timeframe_change`
         memo[changeTimeframeKey] = payload[key][changeTimeframeKey]
         return memo

--- a/test/v1/index.test.js
+++ b/test/v1/index.test.js
@@ -666,6 +666,28 @@ test('check coingecko spot price with mapped ticker', async (t) => {
   })
 })
 
+test('check coingecko spot price with arbitrary timeframe ticker', async (t) => {
+  const timeframe = '1y'
+  const url = `/v2/relative/provider/coingecko/bat/usd/${timeframe}`
+  const { body } = await ratiosAgent
+    .get(url)
+    .expect(ok)
+  const { payload } = body
+  t.true(!_.isNaN(new Date(body.lastUpdated).valueOf()))
+  const key = `usd_${timeframe}_change`
+  const bat = {
+    usd: payload.bat.usd,
+    usd_24h_change: payload.bat.usd_24h_change,
+    [key]: payload.bat[key]
+  }
+  t.deepEqual(body, {
+    lastUpdated: body.lastUpdated,
+    payload: {
+      bat
+    }
+  })
+})
+
 test('keywords can be passed to retreive historical prices', async (t) => {
   const url = (keyword) => `/v2/history/coingecko/bat/usd/${keyword}`
   const { body } = await ratiosAgent

--- a/versions/v2/coingecko.js
+++ b/versions/v2/coingecko.js
@@ -138,7 +138,7 @@ async function spotPrice ({
   }
   const result = await passthrough({}, {
     refresh,
-    path: `/api/v3/simple/price?ids=${a1Id}&vs_currencies=${b1Id}&include_24hr_change=true`
+    path: `/api/v3/simple/price?ids=${a1Id}&vs_currencies=${b1Id}`
   })
 
   result.payload = _.reduce(result.payload, (memo, value, key) => {

--- a/versions/v2/index.js
+++ b/versions/v2/index.js
@@ -50,13 +50,13 @@ swagger.document('/history/coingecko/{a}/{b}/{from}/{until}', 'get', {
 })
 
 router.get(
-  '/relative/provider/:provider/:a/:b',
+  '/relative/provider/:provider/:a/:b/:from?/:until?',
   log,
   // no response check
   checkers.response(coingeckoSpotPrice),
   rates.coingeckoSpotPrice
 )
-swagger.document('/relative/provider/{provider}/{a}/{b}', 'get', {
+swagger.document('/relative/provider/{provider}/{a}/{b}/{from}/{until}', 'get', {
   tags: ['ratios'],
   summary: 'get currency from coingecko',
   description: 'get currency from coingecko',
@@ -64,6 +64,16 @@ swagger.document('/relative/provider/{provider}/{a}/{b}', 'get', {
     swagger.param.string('provider', 'coingecko'),
     swagger.param.currency('a', 'basic-attention-token'),
     swagger.param.currency('b', 'usd'),
+    swagger.param.date('from', {
+      allowEmptyValue: true,
+      oneOfExtra: [{
+        type: 'string',
+        enum: ['live', '1d', '1w', '1m', '3m', '1y', 'all']
+      }]
+    }),
+    swagger.param.date('until', {
+      allowEmptyValue: true
+    }),
     swagger.query.string('refresh')
   ],
   responses: {


### PR DESCRIPTION
`check coingecko spot price with arbitrary timeframe ticker` test holds an example of how the values will be presented
https://github.com/brave-intl/bat-ratios/compare/add-arbitrary-time-comparison-to-spot?expand=1#diff-0ec73cd9dddff956e659e5db8394767e9b02a9a2fdb7f5483ae822de86139e90R681