### PR TITLE
Pin currency version to 1.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "repository": "git@github.com:brave-intl/bat-ratios.git",
   "license": "ISC",
   "dependencies": {
-    "@brave-intl/currency": "^1.6.6",
+    "@brave-intl/currency": "1.6.6",
     "@sentry/node": "^6.2.5",
     "ava": "^4.0.0-rc.1",
     "debug": "^4.3.1",


### PR DESCRIPTION
I want to pin this version before publishing version 1.6.7 of currency (https://github.com/brave-intl/currency/pull/55) because I'm not 100% there won't be issues with 1.6.7.  I want to make sure bat-ratios prod is pinned to 1.6.6 (current), create a new release of currency (1.6.7), then test bat-ratios in dev using the 1.6.7 of currency.  Then repeat for 1.6.8